### PR TITLE
Fix contributing guidelines link in web.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ const string = stringify(object);
 
 ## Contributing:
 
-Interested in contributing to **VDF**? Contributions are welcome, and are accepted via pull requests. Please [review these guidelines](contributing.md) before submitting any pull requests.
+Interested in contributing to **VDF**? Contributions are welcome, and are accepted via pull requests. Please [review these guidelines](https://github.com/node-steam/vdf/blob/b2487111b034f2f518eff14e96af2f06e6b54734/contributing.md) before submitting any pull requests.
 
 ### Help:
 


### PR DESCRIPTION
The link in the web redirects to https://node-steam.github.io/vdf/contributing.md, so I change it for the [permalink](https://github.com/node-steam/vdf/blob/b2487111b034f2f518eff14e96af2f06e6b54734/contributing.md).