### PR TITLE
fix unsafe integer strings getting rounded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,11 +79,11 @@ export const parse = (text: string): any => {
                     continue;
                 }
 
-                if (val !== '' && !isNaN(val)) val = +val;
-                if (val === 'true')            val = true;
-                if (val === 'false')           val = false;
-                if (val === 'null')            val = null;
-                if (val === 'undefined')       val = undefined;
+                if (val !== '' && !isNaN(val) && String(+val) === val) val = +val;
+                if (val === 'true')                                    val = true;
+                if (val === 'false')                                   val = false;
+                if (val === 'null')                                    val = null;
+                if (val === 'undefined')                               val = undefined;
 
                 stack[stack.length - 1][key] = val;
             }


### PR DESCRIPTION
Currently a string like "18446744073709551615" gets converted to a **rounded** integer 18446744073709552000

Valve in fact uses extremely long numerical game ids, so this is an issue SRM has been seeing. Should be fixed herein.

Also kind of addresses issue #12 since it just leaves unsafe integers as strings, which is much better than rounding them.